### PR TITLE
Fix CI permissions: Add contents:write for release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The workflow was failing with 403 errors when trying to create releases because the default GITHUB_TOKEN didn't have sufficient permissions.

Added `permissions: contents: write` to the build job to allow:
- Creating releases
- Uploading release assets