### PR TITLE
Refactor domain pattern grouping logic

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Group {
   id: string;
   name: string;
+  enabled: boolean;  // Global on/off toggle for this group
   lightBgColor: string;
   lightTextColor: string;
   darkBgColor: string;
@@ -12,7 +13,8 @@ export interface Domain {
   id: string;
   pattern: string;
   mode: 'light' | 'dark';
-  groupIds: string[];
+  groups?: string[];  // List of group names (optional, omit for "all enabled groups")
+  groupMode?: 'only' | 'except';  // Defaults to 'only' if groups specified
 }
 
 export interface StorageData {


### PR DESCRIPTION
This change introduces a more intuitive group management system:

1. Groups now have an 'enabled' field for global on/off toggling
2. Domains support three filtering modes:
   - Default: use all enabled groups (no configuration needed)
   - Only: use only specified groups (groupMode: 'only')
   - Except: use all groups except specified (groupMode: 'except')

Key improvements:
- Eliminates repetition in domain configuration
- Default behavior requires zero configuration
- More flexible group filtering per domain
- Backwards compatible with automatic data migration

Technical changes:
- Updated Group interface to include 'enabled' boolean
- Updated Domain interface to use 'groups' (names) and 'groupMode'
- Removed 'groupIds' in favor of name-based references
- Enhanced export/import to support new schema
- Added migration logic for existing data
- Updated UI to support new filtering modes