### PR TITLE
Fix data_collection_permissions format in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,7 +29,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "makeitpop@example.com",
-      "data_collection_permissions": false
+      "data_collection_permissions": {}
     }
   }
 }


### PR DESCRIPTION
Changed from boolean false to empty object {} as required by Firefox. The field expects an object, not a boolean value.