### PR TITLE
Update version number display

### DIFF
--- a/scripts/inject-version.js
+++ b/scripts/inject-version.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Get git commit hash
+let gitHash = 'unknown';
+try {
+  gitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+} catch (error) {
+  console.warn('Warning: Could not get git commit hash:', error.message);
+}
+
+// Read base manifest from public/
+const manifestPath = resolve(__dirname, '../public/manifest.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+
+// Read version from package.json
+const packageJsonPath = resolve(__dirname, '../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const baseVersion = packageJson.version;
+
+// Inject version_name with git hash
+manifest.version = baseVersion;
+manifest.version_name = `${baseVersion}-${gitHash}`;
+
+// Write to dist/
+const outputPath = resolve(__dirname, '../dist/manifest.json');
+writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+
+console.log(`✓ Injected version: ${manifest.version_name}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { copyFileSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
 
 const entry = process.env.ENTRY || 'content';
 const entryPath = entry === 'settings' ? 'src/settings/settings.ts' : `src/${entry}.ts`;
@@ -28,7 +29,16 @@ export default defineConfig({
         if (entry === 'settings') {
           // Copy static files after final build
           try { mkdirSync('dist', { recursive: true }); } catch {}
-          copyFileSync('public/manifest.json', 'dist/manifest.json');
+
+          // Inject version with git commit hash into manifest.json
+          try {
+            execSync('node scripts/inject-version.js', { stdio: 'inherit' });
+          } catch (error) {
+            console.error('Error injecting version:', error);
+            // Fallback to direct copy if script fails
+            copyFileSync('public/manifest.json', 'dist/manifest.json');
+          }
+
           copyFileSync('src/settings/settings.html', 'dist/settings.html');
           copyFileSync('src/settings/settings.css', 'dist/settings.css');
           copyFileSync('src/popup.html', 'dist/popup.html');


### PR DESCRIPTION
- Create build script that injects git commit hash into version_name field
- Update vite config to run version injection during build
- Manifest now shows version_name as "X.Y.Z-<commit>" for easy identification
- Eliminates need to manually bump version for testing different commits