### PR TITLE
Fix drop shadow display on mobile

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -122,7 +122,10 @@ function highlightTextNode(node: Text, phraseMap: Map<string, {bgColor: string, 
     span.style.backgroundColor = match.bgColor;
     span.style.color = match.textColor;
     span.style.padding = '1px';
-    span.style.boxShadow = '1px 1px #e5e5e5';
+    // Use darker shadow for light mode, even darker for dark mode
+    span.style.boxShadow = globalMode === 'dark'
+      ? '1px 1px rgba(0, 0, 0, 0.5)'
+      : '1px 1px rgba(0, 0, 0, 0.2)';
     span.style.borderRadius = '3px';
     span.style.fontStyle = 'inherit';
     span.setAttribute('data-makeitpop-highlight', 'true');
@@ -209,6 +212,7 @@ function debounce(func: Function, wait: number): Function {
 
 // Global state for highlighting with concurrency control
 let globalPhraseMap: Map<string, {bgColor: string, textColor: string}> | null = null;
+let globalMode: 'light' | 'dark' = 'light'; // Track current mode for styling
 let shouldHighlight = false; // Flag indicating highlight needed
 let isHighlighting = false; // Lock to prevent concurrent execution
 let currentLoopNumber = 0; // Unique ID for each highlighting pass
@@ -275,6 +279,7 @@ async function highlightPage() {
   }
 
   globalPhraseMap = phraseMap;
+  globalMode = mode; // Store mode globally for styling
 
   // Initial highlight
   currentLoopNumber = Math.floor(Math.random() * 1000000000);


### PR DESCRIPTION
Previously used a hardcoded light gray (#e5e5e5) box shadow which looked great on light backgrounds but created a brighter-than-background shadow on dark backgrounds. Now uses mode-aware rgba shadows:
- Light mode: rgba(0, 0, 0, 0.2) for subtle dark shadow
- Dark mode: rgba(0, 0, 0, 0.5) for more prominent dark shadow

This ensures shadows always appear darker than the background, providing proper depth perception regardless of theme.