### PR TITLE
Remove version_name from manifest to fix Firefox warning

### DIFF
--- a/scripts/inject-version.js
+++ b/scripts/inject-version.js
@@ -13,25 +13,27 @@ const versionTsContent = readFileSync(versionTsPath, 'utf-8');
 
 // Parse version info from version.ts (simple regex extraction)
 const versionMatch = versionTsContent.match(/BUILD_VERSION = '([^']+)'/);
-const versionNameMatch = versionTsContent.match(/BUILD_VERSION_NAME = '([^']+)'/);
 
-if (!versionMatch || !versionNameMatch) {
+if (!versionMatch) {
   throw new Error('Could not parse version.ts - run generate-version.js first');
 }
 
 const version = versionMatch[1];
-const versionName = versionNameMatch[1];
 
 // Read base manifest from public/
 const manifestPath = resolve(__dirname, '../public/manifest.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
 
-// Inject version info
+// Inject version info (only the numeric version, not version_name)
+// version_name causes Firefox warnings since it's Chrome-specific
+// Build version with commit hash is shown in settings page instead
 manifest.version = version;
-manifest.version_name = versionName;
+
+// Remove version_name if it exists (shouldn't, but clean up just in case)
+delete manifest.version_name;
 
 // Write to dist/
 const outputPath = resolve(__dirname, '../dist/manifest.json');
 writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
 
-console.log(`✓ Injected manifest version: ${versionName}`);
+console.log(`✓ Injected manifest version: ${version}`);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -329,20 +329,23 @@ async function init() {
 }
 
 function displayVersionInfo() {
-  // Display build-time version
+  // Display build-time version (includes commit hash)
   const buildVersionEl = document.getElementById('buildVersion')!;
   buildVersionEl.textContent = BUILD_VERSION_NAME;
-  buildVersionEl.title = `Built at: ${BUILD_TIME}`;
+  buildVersionEl.title = `Built at: ${BUILD_TIME}\nCommit: ${BUILD_COMMIT}`;
 
-  // Display runtime version from manifest
+  // Display runtime version from manifest (just semantic version)
   const manifest = browserAPI.runtime.getManifest();
   const runtimeVersionEl = document.getElementById('runtimeVersion')!;
-  const runtimeVersion = manifest.version_name || manifest.version;
+  const runtimeVersion = manifest.version;
   runtimeVersionEl.textContent = runtimeVersion;
 
-  // Check for mismatch
+  // Check for mismatch: compare base version numbers only
+  // Build version is like "1.0.0-5f9c794", runtime is like "1.0.0"
   const versionWarning = document.getElementById('versionWarning')!;
-  if (BUILD_VERSION_NAME !== runtimeVersion) {
+  const buildBaseVersion = BUILD_VERSION_NAME.split('-')[0]; // Extract "1.0.0" from "1.0.0-5f9c794"
+
+  if (buildBaseVersion !== runtimeVersion) {
     versionWarning.style.display = 'block';
   } else {
     versionWarning.style.display = 'none';


### PR DESCRIPTION
- Remove version_name injection (Chrome-specific, causes Firefox warnings)
- Keep version display in settings page (shows build version with commit hash)
- Update comparison logic to compare base versions only
- Build version: "1.0.0-5f9c794" (from compiled code)
- Runtime version: "1.0.0" (from manifest)
- Mismatch warning only if base versions differ (e.g., 1.0.1 vs 1.0.0)

This eliminates Firefox's "unexpected property" warning while preserving the ability to see exactly which commit is built into the extension.