### PR TITLE
Simplify URL wildcard and subdomain handling

### DIFF
--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -27,7 +27,11 @@
 
   <h2>Domains</h2>
   <div>
-    <input type="text" id="domainPattern" placeholder="Domain pattern (e.g., *.linkedin.com)"><br>
+    <input type="text" id="domainPattern" placeholder="Domain (e.g., linkedin.com)"><br>
+    <strong>Match:</strong>
+    <label><input type="radio" name="domainMatchMode" value="domain-and-www" checked> Domain + www</label>
+    <label><input type="radio" name="domainMatchMode" value="all-subdomains"> All subdomains</label>
+    <label><input type="radio" name="domainMatchMode" value="exact"> Exact match</label><br>
     <strong>Mode:</strong>
     <label><input type="radio" name="domainMode" value="light" checked> Light</label>
     <label><input type="radio" name="domainMode" value="dark"> Dark</label><br>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,8 @@ export interface Group {
 
 export interface Domain {
   id: string;
-  pattern: string;
+  domain: string;  // Just the domain without wildcards (e.g., "linkedin.com")
+  matchMode: 'domain-and-www' | 'all-subdomains' | 'exact';  // How to match the domain
   mode: 'light' | 'dark';
   groups?: string[];  // List of group names (optional, omit for "all enabled groups")
   groupMode?: 'only' | 'except';  // Defaults to 'only' if groups specified


### PR DESCRIPTION
Replace the wildcard pattern syntax (*.domain.com) with a more intuitive interface using three explicit match modes:

1. "Domain + www" (default) - Matches both domain.com and www.domain.com
2. "All subdomains" - Matches domain.com and all subdomains
3. "Exact match" - Matches only the exact domain entered

Changes:
- Replace 'pattern' field with 'domain' + 'matchMode' in Domain interface
- Update settings UI with radio buttons for match mode selection
- Update domain matching logic in content script
- Add migration code to convert old pattern format to new schema
- Add backward compatibility in import/export
- Update all error messages to use new field names

The default "Domain + www" mode covers the most common use case where users want to match both the root domain and www subdomain without matching other subdomains.