### PR TITLE
Fix settings page group selection bug

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1049,6 +1049,8 @@ function createDomainCard(d: Domain): HTMLElement {
 
   groupSelection.appendChild(exceptGroupsList);
 
+  editMode.appendChild(groupSelection);
+
   // Add event listeners to show/hide group lists
   const groupingRadios = editMode.querySelectorAll('.edit-domain-grouping');
   groupingRadios.forEach(radio => {
@@ -1061,8 +1063,6 @@ function createDomainCard(d: Domain): HTMLElement {
       exceptList.classList.toggle('visible', selected === 'except');
     });
   });
-
-  editMode.appendChild(groupSelection);
 
   // Button group
   const buttonGroup = createElement('div', { className: 'button-group' });


### PR DESCRIPTION
The event listeners for showing/hiding group checkbox lists were being attached before the radio buttons were added to the DOM. Moved the appendChild call before the querySelector to ensure elements exist when event listeners are attached.

Fixes the issue where 'Only these groups' and 'All groups except' options would not expand their checkbox lists in the settings page.