### PR TITLE
Build extension on non-main branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,17 @@ jobs:
           echo "Branch: ${{ github.ref_name }}" >> dist/build-info.txt
           echo "Build date: $(date -u)" >> dist/build-info.txt
 
+      - name: Sanitize branch name for artifacts
+        id: sanitize
+        run: |
+          SAFE_BRANCH=$(echo "${{ github.ref_name }}" | sed 's/[\/:]/-/g')
+          echo "branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
+          echo "Sanitized branch name: ${SAFE_BRANCH}"
+
       - name: Upload extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: extension-build-${{ github.ref_name }}-${{ github.sha }}
+          name: extension-build-${{ steps.sanitize.outputs.branch }}-${{ github.sha }}
           path: dist/
           retention-days: 30
 
@@ -57,7 +64,7 @@ jobs:
       - name: Upload extension zip
         uses: actions/upload-artifact@v4
         with:
-          name: extension-zip-${{ github.ref_name }}-${{ github.sha }}
+          name: extension-zip-${{ steps.sanitize.outputs.branch }}-${{ github.sha }}
           path: makeitpop-extension.zip
           retention-days: 30
 


### PR DESCRIPTION
Changes:
- Build workflow now triggers on all branches and PRs
- GitHub releases are only created for pushes to main branch
- Artifact names include branch name for easier identification
- Allows testing extension builds from PRs without creating releases

This enables PR testing while keeping releases clean and main-only.