### PR TITLE
Add raw mode editing

### DIFF
--- a/src/settings/settings.css
+++ b/src/settings/settings.css
@@ -344,6 +344,13 @@ textarea {
   margin-bottom: 10px;
 }
 
+.phrase-raw-textarea {
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  min-height: 200px;
+}
+
 .color-picker-group {
   display: flex;
   gap: 20px;
@@ -386,6 +393,21 @@ textarea {
 .phrase-input-container input {
   flex: 1;
   margin: 0;
+}
+
+.raw-mode-toggle {
+  font-size: 12px;
+  padding: 6px 12px;
+  margin: 0;
+}
+
+.phrase-normal-mode,
+.phrase-raw-mode {
+  animation: fadeIn 0.2s;
+}
+
+.phrase-raw-mode {
+  margin-top: 10px;
 }
 
 /* Radio Buttons */


### PR DESCRIPTION
Users can now toggle between normal tag-based editing and raw text mode for managing phrases. Raw mode displays all phrases as newline-separated text in a textarea, making it easier to:
- Bulk edit phrases
- Import large lists of phrases
- Copy/paste from external sources

The toggle button switches between modes while preserving all edits. When saving, phrases are collected from whichever mode is currently active.