### PR TITLE
Investigate highlight color mismatch issue

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -135,11 +135,8 @@ function highlightTextNode(node: Text, phraseMap: Map<string, {bgColor: string, 
     const span = document.createElement('span');
     span.style.backgroundColor = match.bgColor;
     span.style.color = match.textColor;
-    span.style.padding = '1px';
-    // Use darker shadow for light mode, even darker for dark mode
-    span.style.boxShadow = globalMode === 'dark'
-      ? '1px 1px rgba(0, 0, 0, 0.5)'
-      : '1px 1px rgba(0, 0, 0, 0.2)';
+    span.style.padding = '2px 4px';
+    span.style.boxShadow = '1px 1px rgba(0, 0, 0, 0.2)';
     span.style.borderRadius = '3px';
     span.style.fontStyle = 'inherit';
     span.setAttribute('data-makeitpop-highlight', 'true');

--- a/src/settings/settings.css
+++ b/src/settings/settings.css
@@ -240,11 +240,11 @@ input:checked + .toggle-slider:before {
 }
 
 .color-badge {
-  padding: 6px 14px;
-  border-radius: 6px;
+  padding: 2px 4px;
+  border-radius: 3px;
   font-size: 13px;
-  font-weight: 600;
-  border: 1px solid rgba(0,0,0,0.1);
+  font-weight: normal;
+  box-shadow: 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 /* Phrase Tags */


### PR DESCRIPTION
…ghts

The settings page preview was using bold text, generous padding (6px 14px), and a border, while page highlights used minimal padding (1px) and no bold. This created an optical illusion where colors appeared lighter in settings than on actual pages.

Changes:
- Updated settings preview to match page highlight styling (normal weight, 2px 4px padding, box-shadow)
- Increased page highlight padding from 1px to 2px 4px for better appearance
- Standardized box-shadow to always use rgba(0, 0, 0, 0.2) for consistency
- Removed border from preview, added box-shadow to match page rendering

This ensures the color preview accurately represents what users will see on pages.