### PR TITLE
Add build output link to pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,8 @@ jobs:
         with:
           header: extension-build
           message: |
-            [makeitpop-build-${{ steps.sanitize.outputs.short_sha }}.zip](${{ steps.artifact.outputs.artifact-url }}) - [${{ steps.sanitize.outputs.short_sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }})
+            ext:  [makeitpop-build-${{ steps.sanitize.outputs.short_sha }}.zip](${{ steps.artifact.outputs.artifact-url }})
+            sha:  [${{ steps.sanitize.outputs.short_sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }})
 
       - name: Get version from manifest
         id: version


### PR DESCRIPTION
Add links to the built extension within the PR, so that it is easier to download and test it out.