### PR TITLE
Fix GitHub workflow checkout logic

### DIFF
--- a/.github/workflows/mozilla-upload-steps.yml
+++ b/.github/workflows/mozilla-upload-steps.yml
@@ -39,8 +39,8 @@ jobs:
           echo "tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v4
-        # Checkout main to get the latest CHANGELOG.md (not the release tag)
-        # The release tag is only used to download artifacts and generate URLs
+        with:
+          ref: ${{ steps.extract_tag.outputs.tag }}
 
       - name: Download release artifacts
         env:


### PR DESCRIPTION
The workflow was incorrectly checking out main branch to extract the CHANGELOG.md, which would include unreleased changes if main had moved forward after the release tag. Now it correctly checks out the specific release tag to ensure the changelog matches the release being uploaded.