### PR TITLE
Fix git tag matching to prevent false positives

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Check if tag already exists
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.tag }}"; then
+          if git ls-remote --tags origin | grep -qE "\brefs/tags/${{ steps.version.outputs.tag }}$"; then
             echo "Error: Tag ${{ steps.version.outputs.tag }} already exists!"
             exit 1
           fi


### PR DESCRIPTION
Fixes tag existence check in create-release workflow to match exact tags only.\n\n**Why:** The previous grep pattern would incorrectly match tags like v1.0.3-beta or v1.0.30 when checking for v1.0.3, causing false positive "tag already exists" errors.