### PR TITLE
Fix test-setup to include storage.onChanged mock

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,6 +6,9 @@ global.chrome = {
     local: {
       get: vi.fn().mockResolvedValue({}),
     },
+    onChanged: {
+      addListener: vi.fn(),
+    },
   },
 } as any;
 


### PR DESCRIPTION
The content.ts module calls browserAPI.storage.onChanged.addListener at the top level, so the test environment needs this mock to be available.