### PR TITLE
Fix Mozilla upload workflow warnings and timeout

### DIFF
--- a/.github/workflows/mozilla-upload-steps.yml
+++ b/.github/workflows/mozilla-upload-steps.yml
@@ -130,8 +130,7 @@ jobs:
                 "release_notes": {
                   "en-US": $release_notes
                 },
-                "license": "MIT",
-                "source": "makeitpop-source.zip"
+                "license": "MIT"
               }
             }' > amo-metadata.json
 
@@ -190,5 +189,6 @@ jobs:
           channel: listed
           apiKey: ${{ secrets.MOZILLA_JWT_ISSUER }}
           apiSecret: ${{ secrets.MOZILLA_JWT_SECRET }}
-          addon-guid: ${{ vars.MOZILLA_EXTENSIONS_ID }}
-          amoMetadata: amo-metadata.json
+          metaDataFile: amo-metadata.json
+          sourceCode: makeitpop-source.zip
+          timeout: 60000


### PR DESCRIPTION
Fixes the warnings and timeout issues when uploading to Mozilla Add-ons.

**Changes:**
- Remove deprecated `addon-guid` parameter (now read from manifest.json automatically)
- Rename `amoMetadata` to `metaDataFile` (new parameter name)
- Add `sourceCode` parameter for source archive (moved from metadata file)
- Add 60-second timeout to avoid waiting forever for manual review

**Note:** The workflow will still "fail" after timeout because Mozilla reviews listed extensions manually before signing. The upload itself succeeds - it just can't download the signed XPI immediately.