### PR TITLE
Make settings page mobile-friendly with responsive layout

### DIFF
--- a/.claude/commands/fetch_pr_comments.md
+++ b/.claude/commands/fetch_pr_comments.md
@@ -1,0 +1,19 @@
+# Fetch PR Comments
+
+When the user runs this command, help them fetch PR review comments by:
+
+1. First, get the current branch name and find the associated PR number
+2. Output a shell command for them to run that will fetch all PR comment bodies
+
+The command should use the GitHub CLI to fetch PR comments in a clean, readable format.
+
+Example output format:
+
+```shell
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments --jq '.[].body'
+```
+
+Make sure to:
+- Determine the repo owner and name from the git remote
+- Find the PR number associated with the current branch
+- Provide the exact command ready to copy and paste

--- a/src/settings/settings.css
+++ b/src/settings/settings.css
@@ -1297,17 +1297,10 @@ input:checked + .toggle-slider {
 @media (max-width: 768px) {
   /* Remove max-width constraints for full mobile width */
   .header,
-  .tab-nav,
   .content {
     max-width: 100%;
     padding-left: 16px;
     padding-right: 16px;
-  }
-
-  /* Ensure body uses full viewport */
-  body {
-    margin: 0;
-    padding: 0;
   }
 
   .header {
@@ -1458,8 +1451,8 @@ input:checked + .toggle-slider {
   }
 
   .phrase-tag button {
-    min-width: 24px;
-    min-height: 24px;
+    min-width: 36px;
+    min-height: 36px;
     padding: 4px;
   }
 
@@ -1529,7 +1522,6 @@ input:checked + .toggle-slider {
     bottom: 20px;
     right: 16px;
     left: 16px;
-    max-width: calc(100% - 32px);
   }
 
   /* Empty state */

--- a/src/settings/settings.css
+++ b/src/settings/settings.css
@@ -1289,3 +1289,321 @@ input:checked + .toggle-slider {
   border-color: #ff6b6b;
   color: #ff8080;
 }
+
+/* ========================================
+   MOBILE RESPONSIVE STYLES
+   ======================================== */
+
+@media (max-width: 768px) {
+  /* Remove max-width constraints for full mobile width */
+  .header,
+  .tab-nav,
+  .content {
+    max-width: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  /* Ensure body uses full viewport */
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .header {
+    padding: 20px 16px;
+  }
+
+  .header h1 {
+    font-size: 24px;
+  }
+
+  /* Touch-friendly tab navigation */
+  .tab-nav {
+    padding: 0 12px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+    /* Add safe area support for notched devices */
+    padding-left: max(12px, env(safe-area-inset-left));
+    padding-right: max(12px, env(safe-area-inset-right));
+  }
+
+  .tab-nav::-webkit-scrollbar {
+    display: none; /* Chrome/Safari */
+  }
+
+  .tab-button {
+    padding: 14px 20px;
+    font-size: 15px;
+    white-space: nowrap;
+    min-height: 44px; /* Minimum touch target */
+  }
+
+  /* Content area */
+  .content {
+    padding: 20px 16px;
+  }
+
+  /* Touch-friendly buttons - minimum 44x44px (Apple HIG) */
+  button {
+    min-height: 44px;
+    font-size: 16px;
+    padding: 12px 20px;
+  }
+
+  /* Larger toggle switches for easier tapping */
+  .toggle-switch {
+    width: 52px;
+    height: 28px;
+  }
+
+  .toggle-slider:before {
+    height: 22px;
+    width: 22px;
+  }
+
+  input:checked + .toggle-slider:before {
+    transform: translateX(24px);
+  }
+
+  /* Prevent iOS zoom on input focus (16px minimum) */
+  input[type="text"],
+  input[type="color"],
+  textarea {
+    font-size: 16px;
+  }
+
+  textarea {
+    min-height: 120px;
+  }
+
+  /* Cards - more compact on mobile */
+  .card {
+    padding: 16px;
+    margin-bottom: 12px;
+    border-radius: 8px;
+  }
+
+  .card-header {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .card-title {
+    font-size: 17px;
+  }
+
+  /* Stack color pickers vertically on mobile */
+  .color-picker-group {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .color-picker-item {
+    width: 100%;
+  }
+
+  /* Larger color picker buttons */
+  input[type="color"] {
+    width: 60px;
+    height: 50px;
+    border-radius: 8px;
+  }
+
+  .color-inputs {
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .color-input-wrapper {
+    gap: 8px;
+  }
+
+  .color-hex {
+    font-size: 14px;
+    padding: 12px;
+    min-width: 90px;
+  }
+
+  /* Button groups - stack vertically or allow wrapping */
+  .button-group {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .card-footer {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .card-footer-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .card-footer-actions button {
+    width: 100%;
+  }
+
+  /* Phrase tags - better touch targets */
+  .phrase-tags {
+    gap: 8px;
+  }
+
+  .phrase-tag {
+    padding: 8px 14px;
+    font-size: 14px;
+  }
+
+  .phrase-tag button {
+    min-width: 24px;
+    min-height: 24px;
+    padding: 4px;
+  }
+
+  /* Phrase display */
+  .phrases-display {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .phrase-item {
+    padding: 6px 10px;
+    font-size: 14px;
+  }
+
+  /* Phrase input area */
+  .phrase-input-area {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .phrase-input-area input {
+    width: 100%;
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .phrase-input-area .btn,
+  .phrase-input-area button {
+    width: 100%;
+    min-height: 44px;
+  }
+
+  /* Group selection */
+  .group-selection {
+    padding: 12px;
+  }
+
+  .checkbox-list {
+    margin-left: 20px;
+  }
+
+  .checkbox-list label,
+  .radio-group label {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding: 10px 8px;
+  }
+
+  /* Settings sections */
+  .settings-section {
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+
+  .settings-section h3 {
+    font-size: 17px;
+  }
+
+  .settings-section p {
+    font-size: 15px;
+    line-height: 1.5;
+  }
+
+  /* Toast notifications - full width on mobile */
+  .toast {
+    bottom: 20px;
+    right: 16px;
+    left: 16px;
+    max-width: calc(100% - 32px);
+  }
+
+  /* Empty state */
+  .empty-state {
+    padding: 20px 16px;
+  }
+
+  .empty-state h2 {
+    font-size: 20px;
+  }
+
+  .empty-state h3 {
+    font-size: 17px;
+  }
+
+  .empty-state-intro {
+    font-size: 15px;
+  }
+
+  /* Mode preview */
+  .highlight-preview {
+    padding: 12px;
+    font-size: 15px;
+  }
+
+  /* Icon buttons */
+  .btn-icon,
+  button.icon-only {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+    font-size: 20px;
+  }
+
+  /* Add button */
+  .add-button {
+    position: sticky;
+    top: 60px; /* Below sticky tab nav */
+    z-index: 10;
+    margin-bottom: 16px;
+    width: 100%;
+    float: none;
+  }
+
+  /* Domain info */
+  .domain-info {
+    font-size: 15px;
+  }
+
+  /* Mode toggle bar */
+  .mode-toggle-bar {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .mode-toggle {
+    width: 100%;
+  }
+
+  .mode-toggle-btn {
+    flex: 1;
+    padding: 10px 14px;
+    font-size: 14px;
+    min-height: 44px;
+  }
+
+  /* Group name input */
+  .group-name input {
+    font-size: 18px;
+  }
+
+  /* Improve spacing for lists */
+  #groupsList,
+  #domainsList {
+    margin-top: 16px;
+  }
+}

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
   <title>Make It Pop - Settings</title>
   <link rel="stylesheet" href="settings.css">
 </head>


### PR DESCRIPTION
Add comprehensive mobile improvements to match the popup's mobile UX:
- Add viewport meta tag for proper mobile scaling
- Implement 44x44px minimum touch targets for all interactive elements
- Stack color pickers vertically on mobile for better usability
- Larger toggle switches (52x28px) for easier tapping
- Full-width layout with 16px side padding
- Prevent iOS zoom on input focus (16px font minimum)
- Touch-friendly tab navigation with horizontal scrolling
- Full-width buttons in card footers and input areas
- Support for safe-area insets on notched devices
- Optimized spacing and font sizes for mobile readability

Matches the mobile improvements from commit 0fa250d for the popup.

Also added a handy /fetch_pr_comments for Claude Code to make things easier.